### PR TITLE
SCRUM-84 cancelar partida

### DIFF
--- a/src/entities/game/game_utils.py
+++ b/src/entities/game/game_utils.py
@@ -128,6 +128,9 @@ def get_player_name(player_id):
 def get_players_names(game_id):
     return get_game_by_id(game_id=game_id)['player_names']
 
+def finish_game(game_id):
+    repo.edit_game_state(game_id=game_id, new_state="finished")
+
 def is_players_turn(game_id, player_id):
     try:
         game = get_game_by_id(game_id=game_id)

--- a/src/interfaces/game_endpoints.py
+++ b/src/interfaces/game_endpoints.py
@@ -119,8 +119,8 @@ async def cancel_game(game_id: str, request: LeaveGameRequest):
         raise HTTPException(status_code=403, detail="No se puede eliminar un juego que ya comenzó o terminó")
 
     # Verificar que el jugador sea el creador del juego
-    if game["creator"] == request.player_id and game["state"] == "waiting":
-        raise HTTPException(status_code=403, detail="El creador del juego no puede abandonar la partida")
+    if game["creator"] != request.player_id:
+        raise HTTPException(status_code=403, detail="Sólo puede cancelar la partida el creador del juego")
     
     # Avisar a los jugadores que se cancela la partida
     await public_manager.broadcast({"type":"GameClosed","payload": "Game Closed, disconnected"})

--- a/src/interfaces/game_endpoints.py
+++ b/src/interfaces/game_endpoints.py
@@ -123,7 +123,9 @@ async def cancel_game(game_id: str, request: LeaveGameRequest):
         raise HTTPException(status_code=403, detail="Sólo puede cancelar la partida el creador del juego")
     
     # Avisar a los jugadores que se cancela la partida
-    await public_manager.broadcast({"type":"GameClosed","payload": "Game Closed, disconnected"})
+    await game_socket_manager.broadcast_game(game_id,{"type":"GameClosed","payload": "Game Closed, disconnected"})
+    
+    return Response(status_code=200)
 
 
 @router.post("/{game_id}/skip")

--- a/src/interfaces/game_endpoints.py
+++ b/src/interfaces/game_endpoints.py
@@ -4,7 +4,8 @@ from fastapi import APIRouter, HTTPException, Response
 from entities.game.game_utils import (add_game, get_games, get_game_by_id, 
                                       add_to_game, remove_player_from_game, pass_turn,
                                       start_game_by_id,get_game_status,is_players_turn,make_temp_movement,
-                                      remove_top_movement, apply_temp_movements, complete_figure, FigureResult, block_figure)
+                                      remove_top_movement, apply_temp_movements, complete_figure, FigureResult, block_figure,
+                                      finish_game)
 
 from entities.player.player_utils import add_player
 from schemas.game_schemas import (CreateGameRequest, CreateGameResponse, 
@@ -97,6 +98,7 @@ async def leave_game(game_id: str, request: LeaveGameRequest):
     game["player_names"].remove(player_name)
     game['players'].remove(request.player_id)
     if len(game['players']) <= 1:
+        finish_game(game_id)
         await game_socket_manager.broadcast_game(game_id,{"type":"GameWon","payload": {'player_id' : game['players'][0], 'player_name': game['player_names'][0]}})
         
     #Actualizar la cantidad de jugadores a los que buscan partida.
@@ -124,6 +126,9 @@ async def cancel_game(game_id: str, request: LeaveGameRequest):
     
     # Avisar a los jugadores que se cancela la partida
     await game_socket_manager.broadcast_game(game_id,{"type":"GameClosed","payload": "Game Closed, disconnected"})
+
+    # Cambiar estado del juego a "finished"
+    finish_game(game_id)
     
     return Response(status_code=200)
 
@@ -245,6 +250,9 @@ async def complete_own_figure(game_id: str, request: CompleteFigureRequest):
             game = get_game_by_id(game_id)
             winner_index = game["players"].index(request.player_id)
             winner_name = game["player_names"][winner_index]
+
+            finish_game(game_id)
+
             await game_socket_manager.broadcast_game(game_id,{"type":"GameWon","payload": {'player_id' : request.player_id, 'player_name': winner_name}})
         else:  # FigureResult.COMPLETED
             await game_socket_manager.broadcast_game(game_id,{"type":"FigureMade","payload": get_game_status(game_id)})

--- a/tests/test_game_methods.py
+++ b/tests/test_game_methods.py
@@ -6,7 +6,7 @@ import os
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
 
-from entities.game.game_utils import add_game,get_games, pass_turn, add_to_game, start_game_by_id, remove_player_from_game, get_players_names, get_player_name , make_temp_movement, highlight_figures, remove_top_movement, apply_temp_movements, complete_figure, block_figure
+from entities.game.game_utils import add_game,get_games, pass_turn, add_to_game, start_game_by_id, remove_player_from_game, get_players_names, get_player_name , make_temp_movement, highlight_figures, remove_top_movement, apply_temp_movements, complete_figure, block_figure, finish_game
 
 games = [{'unique_id': '1', 'creator': 'ME', 'state': 'waiting', 'players': ['ME', 'p2'], 'player_names': ['MYNAME', 'p2NAME']}, 
          {'unique_id': '2', 'creator': 'also ME', 'state': 'started', 'players': ['also ME', 'p2'], 'turn': 0},
@@ -56,7 +56,7 @@ def mock_take_figure_card():
 def test_add_game_success(mock_repo):
     mock_repo.create_game.return_value = 'lukaModric'
     assert add_game(game_name = "Test_Game", creator_id = 'darthVader') == 'lukaModric'
-    mock_repo.add_player_to_game.assert_called_once_with(player_id = 'darthVader', game_id = 'lukaModric')
+    mock_repo.add_player_to_game.assert_called_once_with(player_id = 'darthVader', game_id = 'lukaModric', password='')
     mock_repo.create_game.assert_called_once()
 
 def test_get_games(mock_repo):
@@ -330,6 +330,10 @@ def test_block_figure_failure(mock_repo):
     except:
         mock_repo.apply_temp_movements.assert_not_called()
         mock_repo.block_card.assert_not_called()
+
+def test_finish_game(mock_repo):
+    finish_game('1')
+    mock_repo.edit_game_state.assert_called_once_with(game_id='1', new_state='finished')
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Se agrega el endpoint "/game_id/cancel", que permite al creador de una partida cancelarla mientras esté en estado "waiting" (no comenzada). Pasa todos los tests y hay 100% de coverage en el código escrito. También se integra correctamente con el front.