### PR TITLE
Scrum 88 log de partida por chat back

### DIFF
--- a/src/entities/game/game_utils.py
+++ b/src/entities/game/game_utils.py
@@ -442,7 +442,7 @@ def block_figure(game_id, player_id, card_id, i, j):
         figure, color = get_figure(board=board, i = i, j = j)
 
         if game["forbidden_color"] == color:
-            return FigureResult.INVALID
+            return FigureResult.INVALID, -1
 
         if not figure_matches_type(figure_type=card_type, figure=figure):
             raise Exception("Figure doesn't match")
@@ -454,7 +454,7 @@ def block_figure(game_id, player_id, card_id, i, j):
 
         repo.set_forbidden_color(game_id, color)
 
-        return True
+        return True, blocked_player_id
 
     except Exception as e:
         raise e

--- a/src/entities/game/game_utils.py
+++ b/src/entities/game/game_utils.py
@@ -427,6 +427,7 @@ def block_figure(game_id, player_id, card_id, i, j):
                     card_type = card['type']
                     if card['state'] == 'blocked':
                         raise Exception("Card is already blocked")
+                blocked_player_id = player
                 if card['state']== 'blocked':
                     owner_blocked = True
         

--- a/src/interfaces/game_endpoints.py
+++ b/src/interfaces/game_endpoints.py
@@ -1,7 +1,7 @@
 # back/interfaces/game_endpoints.py
 
 from fastapi import APIRouter, HTTPException, Response
-from entities.game.game_utils import (add_game, get_games, get_game_by_id, 
+from entities.game.game_utils import (add_game, get_games, get_game_by_id, get_player_name,
                                       add_to_game, remove_player_from_game, pass_turn,
                                       start_game_by_id,get_game_status,is_players_turn,make_temp_movement,
                                       remove_top_movement, apply_temp_movements, complete_figure, FigureResult, block_figure,
@@ -14,7 +14,7 @@ from schemas.game_schemas import (CreateGameRequest, CreateGameResponse,
                                   applyTempMovementsRequest, CompleteFigureRequest, BlockFigureRequest)
 from interfaces.SocketManagers import public_manager, game_socket_manager 
 from sqlalchemy.exc import NoResultFound
-
+import datetime
 router = APIRouter()
 
 # POST a /games -- Crear partida. recibe JSON de tipo CreateGameRequest en el body
@@ -90,6 +90,11 @@ async def leave_game(game_id: str, request: LeaveGameRequest):
 
     # Avisar a los sockets de la partida sobre el jugador que abandona.
     await game_socket_manager.broadcast_game(game_id,{"type":"PlayerLeft","payload": {'player_id' : request.player_id, 'player_name': player_name}})
+    await game_socket_manager.broadcast_game(game_id, {"type":"ChatMessage","payload":
+                                                                       {   "time":datetime.datetime.now().strftime("%H:%M:%S"),
+                                                                           "player_name":"Partida",
+                                                                           "player_id":"1",
+                                                                           "message":f"{get_player_name(request.player_id)} abandonó la partida."}})
 
     # Avisar a los sockets de la partida de un potencial cambio en el tablero (si el jugador que abandona tenía movimientos parciales hechos)
     if(game["state"]!="waiting"):
@@ -144,6 +149,11 @@ async def skip_turn(game_id: str, request: SkipTurnRequest):
     if(skipped):
         # Avisar a los demás jugadores del nuevo estado de la partida
         await game_socket_manager.broadcast_game(game_id,{"type":"TurnSkipped","payload": get_game_status(game_id=game_id)})
+        await game_socket_manager.broadcast_game(game_id, {"type":"ChatMessage","payload":
+                                                                       {   "time":datetime.datetime.now().strftime("%H:%M:%S"),
+                                                                           "player_name":"Partida",
+                                                                           "player_id":"1",
+                                                                           "message":f"{get_player_name(request.player_id)} saltó su turno."}})
         return Response(status_code=200)
 
     #Si no pudo saltear
@@ -211,6 +221,11 @@ async def make_move(game_id: str,request: MakeMoveRequest):
     
     # Avisar a los sockets de la partida sobre el movimiento hecho
     await game_socket_manager.broadcast_game(game_id,{"type":"MovSuccess","payload": get_game_status(game_id)})
+    await game_socket_manager.broadcast_game(game_id, {"type":"ChatMessage","payload":
+                                                                       {   "time":datetime.datetime.now().strftime("%H:%M:%S"),
+                                                                           "player_name":"Partida",
+                                                                           "player_id":"1",
+                                                                           "message":f"{get_player_name(request.player_id)} realizó un movimiento temporal."}})
 
     return Response(status_code=200)
 
@@ -226,6 +241,11 @@ async def unmake_move(game_id: str,request: UnmakeMoveRequest):
     try:
         remove_top_movement(game_id=game_id,player_id=request.player_id)
         await game_socket_manager.broadcast_game(game_id,{"type":"MoveUnMade","payload": get_game_status(game_id)})
+        await game_socket_manager.broadcast_game(game_id, {"type":"ChatMessage","payload":
+                                                                       {   "time":datetime.datetime.now().strftime("%H:%M:%S"),
+                                                                           "player_name":"Partida",
+                                                                           "player_id":"1",
+                                                                           "message":f"{get_player_name(request.player_id)} deshizo un movimiento parcial."}})
     except:
         raise HTTPException(status_code=403, detail="Invalid Move")
     return Response(status_code=200)
@@ -237,6 +257,11 @@ async def apply_moves(game_id: str,request: applyTempMovementsRequest):
             raise HTTPException(status_code=403, detail="No es tu turno")
         apply_temp_movements(game_id=game_id,player_id=request.player_id)
         await game_socket_manager.broadcast_game(game_id,{"type":"MovesApplied","payload": get_game_status(game_id)})
+        await game_socket_manager.broadcast_game(game_id, {"type":"ChatMessage","payload":
+                                                                       {   "time":datetime.datetime.now().strftime("%H:%M:%S"),
+                                                                           "player_name":"Partida",
+                                                                           "player_id":"1",
+                                                                           "message":f"{get_player_name(request.player_id)} aplicó sus movimientos parciales."}})
     except:
         raise HTTPException(status_code=403, detail="Invalid Move")
     return Response(status_code=200)
@@ -256,6 +281,11 @@ async def complete_own_figure(game_id: str, request: CompleteFigureRequest):
             await game_socket_manager.broadcast_game(game_id,{"type":"GameWon","payload": {'player_id' : request.player_id, 'player_name': winner_name}})
         elif result == FigureResult.COMPLETED:  
             await game_socket_manager.broadcast_game(game_id,{"type":"FigureMade","payload": get_game_status(game_id)})
+            await game_socket_manager.broadcast_game(game_id, {"type":"ChatMessage","payload":
+                                                                       {   "time":datetime.datetime.now().strftime("%H:%M:%S"),
+                                                                           "player_name":"Partida",
+                                                                           "player_id":"1",
+                                                                           "message":f"{get_player_name(request.player_id)} descarto una carta de figura."}})
         else:  # FigureResult.INVALID
             raise HTTPException(status_code=403, detail="You can't use the forbidden color!")
 
@@ -271,11 +301,17 @@ async def complete_own_figure(game_id: str, request: CompleteFigureRequest):
 async def block_opponent_figure(game_id: str,request: BlockFigureRequest):
     try:
         result = block_figure(game_id=game_id, player_id=request.player_id, card_id=request.card_id, i = request.y, j = request.x)
+        blocked_player_id = "123"
         
         if result == FigureResult.INVALID:
             raise HTTPException(status_code=403, detail="You can't use the forbidden color!")
         else:
             await game_socket_manager.broadcast_game(game_id,{"type":"FigureBlocked","payload": get_game_status(game_id)})
+            await game_socket_manager.broadcast_game(game_id, {"type":"ChatMessage","payload":
+                                                                       {   "time":datetime.datetime.now().strftime("%H:%M:%S"),
+                                                                           "player_name":"Partida",
+                                                                           "player_id":"1",
+                                                                           "message":f"{get_player_name(request.player_id)} bloqueo una carta de {get_player_name(blocked_player_id)}."}})
     
     except Exception as e:
         print(e)

--- a/src/interfaces/game_endpoints.py
+++ b/src/interfaces/game_endpoints.py
@@ -130,9 +130,10 @@ async def cancel_game(game_id: str, request: LeaveGameRequest):
     
     # Avisar a los jugadores que se cancela la partida
     await game_socket_manager.broadcast_game(game_id,{"type":"GameClosed","payload": "Game Closed, disconnected"})
-    await public_manager.broadcast({"type":"CreatedGames","payload": get_games()})
     # Cambiar estado del juego a "finished"
     finish_game(game_id)
+    
+    await public_manager.broadcast({"type":"CreatedGames","payload": get_games()})
     
     return Response(status_code=200)
 

--- a/src/interfaces/game_endpoints.py
+++ b/src/interfaces/game_endpoints.py
@@ -14,7 +14,6 @@ from schemas.game_schemas import (CreateGameRequest, CreateGameResponse,
                                   applyTempMovementsRequest, CompleteFigureRequest, BlockFigureRequest)
 from interfaces.SocketManagers import public_manager, game_socket_manager 
 from sqlalchemy.exc import NoResultFound
-import datetime
 router = APIRouter()
 
 # POST a /games -- Crear partida. recibe JSON de tipo CreateGameRequest en el body
@@ -91,8 +90,7 @@ async def leave_game(game_id: str, request: LeaveGameRequest):
     # Avisar a los sockets de la partida sobre el jugador que abandona.
     await game_socket_manager.broadcast_game(game_id,{"type":"PlayerLeft","payload": {'player_id' : request.player_id, 'player_name': player_name}})
     await game_socket_manager.broadcast_game(game_id, {"type":"ChatMessage","payload":
-                                                                       {   "time":datetime.datetime.now().strftime("%H:%M:%S"),
-                                                                           "player_name":"Partida",
+                                                                       {"player_name":"Partida",
                                                                            "player_id":"1",
                                                                            "message":f"{get_player_name(request.player_id)} abandonó la partida."}})
 
@@ -150,7 +148,7 @@ async def skip_turn(game_id: str, request: SkipTurnRequest):
         # Avisar a los demás jugadores del nuevo estado de la partida
         await game_socket_manager.broadcast_game(game_id,{"type":"TurnSkipped","payload": get_game_status(game_id=game_id)})
         await game_socket_manager.broadcast_game(game_id, {"type":"ChatMessage","payload":
-                                                                       {   "time":datetime.datetime.now().strftime("%H:%M:%S"),
+                                                                       {   
                                                                            "player_name":"Partida",
                                                                            "player_id":"1",
                                                                            "message":f"{get_player_name(request.player_id)} saltó su turno."}})
@@ -222,7 +220,7 @@ async def make_move(game_id: str,request: MakeMoveRequest):
     # Avisar a los sockets de la partida sobre el movimiento hecho
     await game_socket_manager.broadcast_game(game_id,{"type":"MovSuccess","payload": get_game_status(game_id)})
     await game_socket_manager.broadcast_game(game_id, {"type":"ChatMessage","payload":
-                                                                       {   "time":datetime.datetime.now().strftime("%H:%M:%S"),
+                                                                       {   
                                                                            "player_name":"Partida",
                                                                            "player_id":"1",
                                                                            "message":f"{get_player_name(request.player_id)} realizó un movimiento temporal."}})
@@ -242,7 +240,7 @@ async def unmake_move(game_id: str,request: UnmakeMoveRequest):
         remove_top_movement(game_id=game_id,player_id=request.player_id)
         await game_socket_manager.broadcast_game(game_id,{"type":"MoveUnMade","payload": get_game_status(game_id)})
         await game_socket_manager.broadcast_game(game_id, {"type":"ChatMessage","payload":
-                                                                       {   "time":datetime.datetime.now().strftime("%H:%M:%S"),
+                                                                       {  
                                                                            "player_name":"Partida",
                                                                            "player_id":"1",
                                                                            "message":f"{get_player_name(request.player_id)} deshizo un movimiento parcial."}})
@@ -258,7 +256,7 @@ async def apply_moves(game_id: str,request: applyTempMovementsRequest):
         apply_temp_movements(game_id=game_id,player_id=request.player_id)
         await game_socket_manager.broadcast_game(game_id,{"type":"MovesApplied","payload": get_game_status(game_id)})
         await game_socket_manager.broadcast_game(game_id, {"type":"ChatMessage","payload":
-                                                                       {   "time":datetime.datetime.now().strftime("%H:%M:%S"),
+                                                                       {   
                                                                            "player_name":"Partida",
                                                                            "player_id":"1",
                                                                            "message":f"{get_player_name(request.player_id)} aplicó sus movimientos parciales."}})
@@ -282,7 +280,7 @@ async def complete_own_figure(game_id: str, request: CompleteFigureRequest):
         elif result == FigureResult.COMPLETED:  
             await game_socket_manager.broadcast_game(game_id,{"type":"FigureMade","payload": get_game_status(game_id)})
             await game_socket_manager.broadcast_game(game_id, {"type":"ChatMessage","payload":
-                                                                       {   "time":datetime.datetime.now().strftime("%H:%M:%S"),
+                                                                       { 
                                                                            "player_name":"Partida",
                                                                            "player_id":"1",
                                                                            "message":f"{get_player_name(request.player_id)} descarto una carta de figura."}})
@@ -300,18 +298,16 @@ async def complete_own_figure(game_id: str, request: CompleteFigureRequest):
 @router.post("/{game_id}/blockFigure")
 async def block_opponent_figure(game_id: str,request: BlockFigureRequest):
     try:
-        result = block_figure(game_id=game_id, player_id=request.player_id, card_id=request.card_id, i = request.y, j = request.x)
-        blocked_player_id = "123"
+        result, blocked_player_id = block_figure(game_id=game_id, player_id=request.player_id, card_id=request.card_id, i = request.y, j = request.x)
         
         if result == FigureResult.INVALID:
             raise HTTPException(status_code=403, detail="You can't use the forbidden color!")
         else:
             await game_socket_manager.broadcast_game(game_id,{"type":"FigureBlocked","payload": get_game_status(game_id)})
             await game_socket_manager.broadcast_game(game_id, {"type":"ChatMessage","payload":
-                                                                       {   "time":datetime.datetime.now().strftime("%H:%M:%S"),
-                                                                           "player_name":"Partida",
+                                                                       {   "player_name":"Partida",
                                                                            "player_id":"1",
-                                                                           "message":f"{get_player_name(request.player_id)} bloqueo una carta de {get_player_name(blocked_player_id)}."}})
+                                                                           "message":f"{get_player_name(request.player_id)} bloqueó una carta de {get_player_name(blocked_player_id)}."}})
     
     except Exception as e:
         print(e)

--- a/src/interfaces/game_endpoints.py
+++ b/src/interfaces/game_endpoints.py
@@ -130,7 +130,7 @@ async def cancel_game(game_id: str, request: LeaveGameRequest):
     
     # Avisar a los jugadores que se cancela la partida
     await game_socket_manager.broadcast_game(game_id,{"type":"GameClosed","payload": "Game Closed, disconnected"})
-
+    await public_manager.broadcast({"type":"CreatedGames","payload": get_games()})
     # Cambiar estado del juego a "finished"
     finish_game(game_id)
     

--- a/src/interfaces/game_endpoints.py
+++ b/src/interfaces/game_endpoints.py
@@ -90,7 +90,8 @@ async def leave_game(game_id: str, request: LeaveGameRequest):
     # Avisar a los sockets de la partida sobre el jugador que abandona.
     await game_socket_manager.broadcast_game(game_id,{"type":"PlayerLeft","payload": {'player_id' : request.player_id, 'player_name': player_name}})
     await game_socket_manager.broadcast_game(game_id, {"type":"ChatMessage","payload":
-                                                                       {"player_name":"Partida",
+                                                                       {   "time":99,
+                                                                           "player_name":"Partida",
                                                                            "player_id":"1",
                                                                            "message":f"{get_player_name(request.player_id)} abandonó la partida."}})
 
@@ -148,7 +149,7 @@ async def skip_turn(game_id: str, request: SkipTurnRequest):
         # Avisar a los demás jugadores del nuevo estado de la partida
         await game_socket_manager.broadcast_game(game_id,{"type":"TurnSkipped","payload": get_game_status(game_id=game_id)})
         await game_socket_manager.broadcast_game(game_id, {"type":"ChatMessage","payload":
-                                                                       {   
+                                                                       {   "time":99,
                                                                            "player_name":"Partida",
                                                                            "player_id":"1",
                                                                            "message":f"{get_player_name(request.player_id)} saltó su turno."}})
@@ -220,7 +221,7 @@ async def make_move(game_id: str,request: MakeMoveRequest):
     # Avisar a los sockets de la partida sobre el movimiento hecho
     await game_socket_manager.broadcast_game(game_id,{"type":"MovSuccess","payload": get_game_status(game_id)})
     await game_socket_manager.broadcast_game(game_id, {"type":"ChatMessage","payload":
-                                                                       {   
+                                                                       {   "time":99,
                                                                            "player_name":"Partida",
                                                                            "player_id":"1",
                                                                            "message":f"{get_player_name(request.player_id)} realizó un movimiento temporal."}})
@@ -240,7 +241,7 @@ async def unmake_move(game_id: str,request: UnmakeMoveRequest):
         remove_top_movement(game_id=game_id,player_id=request.player_id)
         await game_socket_manager.broadcast_game(game_id,{"type":"MoveUnMade","payload": get_game_status(game_id)})
         await game_socket_manager.broadcast_game(game_id, {"type":"ChatMessage","payload":
-                                                                       {  
+                                                                       {   "time":99,
                                                                            "player_name":"Partida",
                                                                            "player_id":"1",
                                                                            "message":f"{get_player_name(request.player_id)} deshizo un movimiento parcial."}})
@@ -256,7 +257,7 @@ async def apply_moves(game_id: str,request: applyTempMovementsRequest):
         apply_temp_movements(game_id=game_id,player_id=request.player_id)
         await game_socket_manager.broadcast_game(game_id,{"type":"MovesApplied","payload": get_game_status(game_id)})
         await game_socket_manager.broadcast_game(game_id, {"type":"ChatMessage","payload":
-                                                                       {   
+                                                                       {   "time":99,
                                                                            "player_name":"Partida",
                                                                            "player_id":"1",
                                                                            "message":f"{get_player_name(request.player_id)} aplicó sus movimientos parciales."}})
@@ -280,7 +281,7 @@ async def complete_own_figure(game_id: str, request: CompleteFigureRequest):
         elif result == FigureResult.COMPLETED:  
             await game_socket_manager.broadcast_game(game_id,{"type":"FigureMade","payload": get_game_status(game_id)})
             await game_socket_manager.broadcast_game(game_id, {"type":"ChatMessage","payload":
-                                                                       { 
+                                                                       {   "time":99,
                                                                            "player_name":"Partida",
                                                                            "player_id":"1",
                                                                            "message":f"{get_player_name(request.player_id)} descarto una carta de figura."}})
@@ -305,7 +306,8 @@ async def block_opponent_figure(game_id: str,request: BlockFigureRequest):
         else:
             await game_socket_manager.broadcast_game(game_id,{"type":"FigureBlocked","payload": get_game_status(game_id)})
             await game_socket_manager.broadcast_game(game_id, {"type":"ChatMessage","payload":
-                                                                       {   "player_name":"Partida",
+                                                                       {   "time":99,
+                                                                           "player_name":"Partida",
                                                                            "player_id":"1",
                                                                            "message":f"{get_player_name(request.player_id)} bloqueó una carta de {get_player_name(blocked_player_id)}."}})
     

--- a/tests/test_game_endpoints.py
+++ b/tests/test_game_endpoints.py
@@ -4,7 +4,7 @@ import os
 from fastapi.testclient import TestClient
 from unittest.mock import patch, MagicMock, AsyncMock
 import pytest
-
+import datetime
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
 
 import main
@@ -101,6 +101,17 @@ def mock_block_figure():
 def mock_finish_game():
     with patch('interfaces.game_endpoints.finish_game') as mock:
         yield mock
+        
+@pytest.fixture
+def mock_get_player_name():
+    with patch('entities.game.game_utils.get_player_name') as mock:
+        yield mock
+
+@pytest.fixture
+def mock_datetime_now():
+    with patch('datetime.datetime') as mock_datetime:
+        mock_datetime.now.return_value = datetime(2023, 1, 1, 12, 0, 0)
+        yield mock_datetime
 
 def test_create_game_success(mock_add_player, mock_add_game, mock_game_socket_manager, mock_get_games):
     # Arrange
@@ -273,7 +284,7 @@ def test_leave_game_success(mock_get_game_status, mock_get_game_by_id, mock_remo
     
     mock_get_game_by_id.return_value = {'players': ['0','Test_Player'], 'state': 'waiting', 'creator': '0', 'player_names': ['mauri', 'rimau']}
     mock_game_socket_manager.broadcast_game = AsyncMock()
-
+    mock_get_player_name.return_value = "Test_Player"
     request_data = {'player_id': 'Test_Player'}
     response = client.post("/games/Test_Game/leave", json=request_data)
 
@@ -326,6 +337,7 @@ def test_skip_turn_success(mock_get_game_status, mock_pass_turn, mock_game_socke
     mock_pass_turn.return_value = True
     mock_get_game_status.return_value = []
     mock_game_socket_manager.broadcast_game = AsyncMock()
+    mock_get_player_name.return_value = "Test_Player"
 
     request_data = {'player_id': 'Test_Player'}
     response = client.post("/games/Test_Game/skip", json=request_data)
@@ -362,6 +374,7 @@ def test_make_temp_move_success(mock_get_game_status, mock_game_socket_manager,m
     mock_make_temp_movement.return_value = True
     mock_game_socket_manager.broadcast_game = AsyncMock()
     mock_get_game_status.return_value = []
+    mock_get_player_name.return_value = "Test_Player"
 
     request_data = {'player_id': 'Test_Player','card_id': '100', 'from_x': 1, 'from_y': 1, 'to_x': 1, 'to_y': 1}
     response = client.post("/games/Test_Game/move", json=request_data)
@@ -422,6 +435,7 @@ def test_make_unmove_success(mock_get_game_status, mock_game_socket_manager,mock
     mock_is_players_turn.return_value = True
     mock_game_socket_manager.broadcast_game = AsyncMock()
     mock_get_game_status.return_value = []
+    mock_get_player_name.return_value = "Test_Player"
 
     request_data = {'player_id': 'Test_Player'}
     response = client.post("/games/Test_Game/unmove", json=request_data)
@@ -451,6 +465,7 @@ def test_apply_move_success(mock_get_game_status, mock_game_socket_manager, mock
     mock_apply_temp_movements.return_value = True
     mock_game_socket_manager.broadcast_game = AsyncMock()
     mock_get_game_status.return_value = []
+    mock_get_player_name.return_value = "Test_Player"
 
     request_data = {'player_id': 'Test_Player'}
     response = client.post("/games/Test_Game/apply", json=request_data)
@@ -492,6 +507,7 @@ def test_complete_figure_success(mock_get_game_status, mock_game_socket_manager,
     mock_game_socket_manager.broadcast_game = AsyncMock()
     mock_get_game_status.return_value = []
     mock_complete_figure.return_value = FigureResult.COMPLETED
+    mock_get_player_name.return_value = "Test_Player"
 
     request_data = {'player_id': 'Test_Player', 'x' : 1, 'y' : 4, 'card_id' : 'test_card'}
     response = client.post("/games/Test_Game/completeFigure", json=request_data)
@@ -515,6 +531,7 @@ def test_complete_figure_failure(mock_get_game_status, mock_game_socket_manager,
 def test_block_figure_success(mock_get_game_status, mock_game_socket_manager, mock_block_figure):
     mock_game_socket_manager.broadcast_game = AsyncMock()
     mock_get_game_status.return_value = []
+    mock_get_player_name.return_value = "Test_Player"
 
     request_data = {'player_id': 'Test_Player', 'x' : 1, 'y' : 4, 'card_id' : 'test_card'}
     response = client.post("/games/Test_Game/blockFigure", json=request_data)

--- a/tests/test_game_methods.py
+++ b/tests/test_game_methods.py
@@ -379,7 +379,7 @@ def test_block_figure_forbidden_color(mock_repo):
     
     result = block_figure(game_id = games[3]['unique_id'], player_id = games[3]['players'][0]['unique_id'], card_id = games[3]['players'][1]['figure_cards'][0]['unique_id'], i = 0, j = 4)
     
-    assert result == FigureResult.INVALID
+    assert result == (FigureResult.INVALID,-1)
     mock_repo.apply_temp_movements.assert_not_called()
     mock_repo.block_card.assert_not_called()
 


### PR DESCRIPTION
-Implementado mensajes de chat para las principales acciones del juego.
-Saqué el campo fecha para los log de partida porque no se usan en front y estaba renegando para mockearlo. 
-Acomodé un poco los test para que pasen con los cambios.
